### PR TITLE
Replace deprecated gulp-util module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var mapStream = require('map-stream');
-var PluginError = require('gulp-util').PluginError;
+var PluginError = require('plugin-error');
 var validator = require('json-dup-key-validator');
 
 module.exports = gulpJsonValidator;

--- a/package.json
+++ b/package.json
@@ -11,15 +11,16 @@
   ],
   "main": "index.js",
   "dependencies": {
-    "gulp-util": "^3.0.7",
     "json-dup-key-validator": "^1.0.0",
-    "map-stream": "0.0.6"
+    "map-stream": "0.0.7",
+    "plugin-error": "^1.0.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "gulp": "^3.9.1",
     "gulp-mocha": "^2.2.0",
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "vinyl": "^2.1.0"
   },
   "scripts": {
     "test": "gulp"

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -1,4 +1,4 @@
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var fs = require('fs');
 var path = require('path');
 var expect = require('chai').expect;
@@ -8,7 +8,7 @@ describe('test', function() {
   describe('plugin', function() {
     var file;
     beforeEach(function() {
-      file = new gutil.File({
+      file = new Vinyl({
         path: path.join(__dirname, './fixture/duplicated-key.json'),
         cwd: __dirname,
         base: path.join(__dirname, './fixture') ,


### PR DESCRIPTION
[The Problem with gulp-util](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5)

`gulp-util` is deprecated and there are drop-in replacements for all the parts used here.